### PR TITLE
Updated mechanism for IO handling with CoffeeScript compiler

### DIFF
--- a/coffee_compile.py
+++ b/coffee_compile.py
@@ -2,10 +2,13 @@ import platform
 
 import sublime_plugin
 import sublime
+import os
+import subprocess
 
 
 PLATFORM_IS_WINDOWS = platform.system() == 'Windows'
 COFFEE_COMMAND = 'coffee.cmd' if PLATFORM_IS_WINDOWS else 'coffee'
+PANEL_NAME = 'coffeescript_output'
 
 
 def _log(msg):
@@ -15,23 +18,40 @@ _log('Platform is "%s"' % platform.system())
 _log('Coffee command is "%s"' % COFFEE_COMMAND)
 
 
+def is_null_empty(value):
+    return value is None or len(value) == 0
+
+
 class CoffeeCompileCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
         text = self._get_text_to_compile()
         window = self.view.window()
-        self._setup_exec_panel(window)
 
-        if PLATFORM_IS_WINDOWS:
-            text = text.replace('\n', '\r\n')
-
-        self._compile(text, window)
+        javascript, error = self._compile(text, window)
+        self._write_output_to_panel(window, javascript, error)
 
     def _compile(self, text, window):
-        window.run_command('exec', {
-            'cmd': [COFFEE_COMMAND, '--print', '--lint', '--eval', text],
-            'quiet': True
-        })
+        args = [COFFEE_COMMAND, '--stdio', '--print', '--lint']
+
+        process = subprocess.Popen(args, stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            startupinfo=self.get_startupinfo())
+        return process.communicate(text)
+
+    def _write_output_to_panel(self, window, javascript, error):
+
+        panel = window.get_output_panel(PANEL_NAME)
+        panel.set_syntax_file('Packages/JavaScript/JavaScript.tmLanguage')
+
+        output_view = window.get_output_panel(PANEL_NAME)
+        output_view.set_read_only(False)
+        edit = output_view.begin_edit()
+        output_view.insert(edit, 0, javascript)
+        output_view.end_edit(edit)
+        output_view.sel().clear()
+        output_view.set_read_only(True)
+        window.run_command('show_panel', {'panel': 'output.' + PANEL_NAME})
 
     def _get_text_to_compile(self):
         region = self._get_selected_region() if self._editor_contains_selected_text() \
@@ -50,6 +70,12 @@ class CoffeeCompileCommand(sublime_plugin.TextCommand):
                 return True
         return False
 
-    def _setup_exec_panel(self, window):
-        panel = window.get_output_panel("exec")
-        panel.set_syntax_file('Packages/JavaScript/JavaScript.tmLanguage')
+    def get_startupinfo(self):
+        info = None
+
+        if os.name == 'nt':
+            info = subprocess.STARTUPINFO()
+            info.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            info.wShowWindow = subprocess.SW_HIDE
+
+        return info


### PR DESCRIPTION
Note, this _works_ on Windows, but I have not tested this on other platforms (though it should work fine because there is nothing Windows specific in the revised code).

From commit msg:

Window.run_command exec no longer used, as it wasn't working properly on
Windows. New alternative is to use subprocess.POpen to send input over
STDIN instead, and it reads back output from STDOUT.

Using a new output panel dedicated to CoffeeScript compiler output rather
than using the one for exec.

Some techniques borrowed from the source of SublimeLinter -
https://github.com/SublimeLinter/SublimeLinter/blob/master/sublimelinter/modules/base_linter.py
