### PR TITLE
Update coffee_compile.py - remove '--lint'

### DIFF
--- a/coffee_compile.py
+++ b/coffee_compile.py
@@ -112,7 +112,7 @@ class CoffeeCompileCommand(sublime_plugin.TextCommand):
     def _get_vanilla_coffee_args(self):
         coffee_executable = self._get_coffee_executable()
 
-        args = [coffee_executable, '--stdio', '--print', '--lint']
+        args = [coffee_executable, '--stdio', '--print']
 
         if SETTINGS.get('bare'):
             args.append('--bare')


### PR DESCRIPTION
Love the sublime package! We Live by CoffeeCompile!

CoffeeScript 1.6.2+ no longer supports '--lint'

Removed it from the command. Perhaps in the future these flags should be set via the settings file.
