### PR TITLE
change Default OSX keymap to use command+shift+c

### DIFF
--- a/Keymaps/Default (OSX).sublime-keymap
+++ b/Keymaps/Default (OSX).sublime-keymap
@@ -1,3 +1,3 @@
 [
-    {"keys": ["ctrl+shift+c"], "command": "coffee_compile"}
+    {"keys": ["super+shift+c"], "command": "coffee_compile"}
 ]

--- a/Keymaps/Default (OSX).sublime-keymap
+++ b/Keymaps/Default (OSX).sublime-keymap
@@ -1,3 +1,4 @@
 [
-    {"keys": ["super+shift+c"], "command": "coffee_compile"}
+    {"keys": ["ctrl+shift+c"], "command": "coffee_compile"}
+	{"keys": ["super+shift+c"], "command": "coffee_compile"}
 ]


### PR DESCRIPTION
The default key map for OSX was using the control+shift+c key combination. To make this more OS X friendly I changed the default key map for OS X to use the command+shift+c key combination.

Great package!
