### PR TITLE
Added syntax support for coffee-script-tmbundle

### DIFF
--- a/CoffeeCompile.sublime-settings
+++ b/CoffeeCompile.sublime-settings
@@ -89,8 +89,9 @@
       */
 ,    "syntax_patterns": [
           "Packages/CoffeeScript/CoffeeScript.tmLanguage"
+     ,    "Packages/CoffeeScript/Syntaxes/CoffeeScript.tmLanguage"
      ,    "Packages/Better CoffeeScript/CoffeeScript.tmLanguage"
      ,    "Packages/Text/Plain text.tmLanguage"
-     
+
      ]
 }


### PR DESCRIPTION
@surjikal 
Added Coffeescript syntax support for 'coffee-script-tmbundle' package. https://github.com/jashkenas/coffee-script-tmbundle which is compatible with Sublime-text 2.
