### PR TITLE
Add support for literate CoffeeScript when a literate syntax is used

### DIFF
--- a/CoffeeCompile.sublime-settings
+++ b/CoffeeCompile.sublime-settings
@@ -90,6 +90,7 @@
 ,    "syntax_patterns": [
           "Packages/CoffeeScript/CoffeeScript.tmLanguage"
      ,    "Packages/Better CoffeeScript/CoffeeScript.tmLanguage"
+     ,    "Packages/Better CoffeeScript/CoffeeScript_Literate.tmLanguage"
      ,    "Packages/Text/Plain text.tmLanguage"
      
      ]

--- a/coffee_compile.py
+++ b/coffee_compile.py
@@ -78,6 +78,8 @@ class CoffeeCompileCommand(sublime_plugin.TextCommand):
 
         try:
             [compiler, options] = settings_adapter(self.settings)['compiler']
+            # Literate option does not depend on settings, but on the files syntax (must be a literate tmLanguage)
+            options['literate'] = 'literate' in self.view.settings().get('syntax').lower()
             javascript = self._compile(coffeescript, compiler, options)
             self._write_javascript_to_panel(javascript, edit)
         except CoffeeCompilationError as e:

--- a/lib/compilers.py
+++ b/lib/compilers.py
@@ -71,6 +71,7 @@ class CoffeeCompilerModule(CoffeeCompiler):
         return 'null'
         return JSON.dumps({
             'bare': options.get('bare', False)
+          , 'literate': options.get('literate', False)
         })
 
 
@@ -107,4 +108,5 @@ class CoffeeCompilerExecutableVanilla(CoffeeCompilerExecutable):
     def _options_to_args(self, options):
         args = ['--stdio', '--print']
         if options.get('bare'): args.append('--bare')
+        if options.get('literate'): args.append('--literate')
         return args


### PR DESCRIPTION
Hi,

I added support for literate CoffeeScript to the plugin.

As you pass in the script using the `stdin`, CoffeeScript needs the `--literate` option to be able to parse it, this is because it normally identifies it via the file extension.
As the literate option does depend on the file and is no global setting, it did not make any sense to me the configure it in the settings.
Next question was how to find out if this is a literate file, I had the option to do this by the file extension, or the syntax type of the file.
Using the **file extension** needs this file to be saved, before CoffeeCompile can be used. Although, the plugins visibility is already bound to the **syntax type** of the editor, that is why I decided to go the same way and check if the syntax contains the `"literate"` literal somehow. I tried to implement this with a more generic check for 'literate', just to be a little more stable when there are some other syntax plugins.
I did the implementation for executable and module usage, and adjusted the default setting to also support the *Better CoffeeScript Literate* syntax.

All I can say is, that this works like charm for me, **but** I have never created any SublimeText plugin, neither have I done anything in Python yet. So please double your attention when reviewing this.