### PR TITLE
Adds a setting controlling syntax highlighting for the compiled output

### DIFF
--- a/CoffeeCompile.sublime-settings
+++ b/CoffeeCompile.sublime-settings
@@ -92,6 +92,13 @@
      ,    "Packages/Better CoffeeScript/CoffeeScript.tmLanguage"
      ,    "Packages/Better CoffeeScript/CoffeeScript_Literate.tmLanguage"
      ,    "Packages/Text/Plain text.tmLanguage"
-     
+
      ]
+
+     /**
+      * Path to the file used for syntax highlighting the compiled output pane.
+      *
+      * e.g. "Packages/Better JavaScript/JavaScript.tmLanguage" if you use Better JavaScript
+      */
+,    "syntax_file_js": "Packages/JavaScript/JavaScript.tmLanguage"
 }

--- a/coffee_compile.py
+++ b/coffee_compile.py
@@ -112,7 +112,12 @@ class CoffeeCompileCommand(sublime_plugin.TextCommand):
 
     def _write_javascript_to_panel(self, javascript, edit):
         panel = self._create_panel()
-        panel.set_syntax_file('Packages/JavaScript/JavaScript.tmLanguage')
+
+        syntaxFileJS = self.settings.get('syntax_file_js', None)
+        if not syntaxFileJS:
+            raise ValueError('missing syntax_file_js setting')
+
+        panel.set_syntax_file(syntaxFileJS)
         panel.display(javascript, edit)
 
     def _write_compile_error_to_panel(self, error, edit):


### PR DESCRIPTION
Useful if using alternate js syntax highlighting package to the default e.g. Better Javascript

Potentially a simple resolution to #40? Working well for me.